### PR TITLE
Add Support for multiple STOP_IDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # HSL Planner
 
-This program makes use of the [Digitransit](https://digitransit.fi/en/developers/) GraphQL APIs to gather realtime route data from the Helsinki [HSL Transit Network](https://www.hsl.fi/en) using GraphQL.
+This program makes use of the [Digitransit](https://digitransit.fi/en/developers/) GraphQL APIs to gather realtime route data from the Helsinki [HSL Transit Network](https://www.hsl.fi/en).
 
-I've built this project to gather the realtime departure schedule from my local transit stops (taking into account delays and cancellations), and display these details in my house.
+I've built this project to gather realtime departure information from my local transit stops (accounting for delays, cancellations, route changes, etc...) to display the results in my home.
 
 ---
 
@@ -13,7 +13,7 @@ I've built this project to gather the realtime departure schedule from my local 
 2. Add a `.env` file to the root folder of your project, with the following information
 
    - `API_KEY` is provided after signing up for a development account on the [Digitransit Portal](https://portal-api.digitransit.fi/)
-   - `STOP_IDS` should be set for your preferred HSL stop location. See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details.
+   - `STOP_IDS` should be set to your preferred HSL stop location(s). See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details.
      - Supports a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321")
 
    ```
@@ -32,5 +32,5 @@ I've built this project to gather the realtime departure schedule from my local 
 
 - [x] Connect to Digitransit API to retrieve local departure information
 - [x] Track multiple STOP_ID values at the same time
-- [ ] Filter specific routes at tracked STOP_ID to exclude any that are not relevant
+- [ ] Filter to only show preferred routes from each tracked STOP_ID.
 - [ ] Interface with a display technology (ex. [TRMNL](https://usetrmnl.com/)) running a service to update the results at regular intervals

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ I've built this project to gather the realtime departure schedule from my local 
 1. Fork the repository and clone it to your local machine
 
 2. Add a `.env` file to the root folder of your project, with the following information
+
    - `API_KEY` is provided after signing up for a development account on the [Digitransit Portal](https://portal-api.digitransit.fi/)
    - `STOP_IDS` should be set for your preferred HSL stop location. See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details.
      - Supports a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321")
+
+3. Run the `main.py` file from the command line
 
 ```
 API_ENDPOINT="https://api.digitransit.fi/routing/v2/hsl/gtfs/v1"

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ I've built this project to gather the realtime departure schedule from my local 
    - `STOP_IDS` should be set for your preferred HSL stop location. See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details.
      - Supports a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321")
 
+   ```
+   API_ENDPOINT="https://api.digitransit.fi/routing/v2/hsl/gtfs/v1"
+
+   API_KEY=[YOUR-API-KEY]
+
+   STOP_IDS=[YOUR-STOP-IDS]
+   ```
+
 3. Run the `main.py` file from the command line
-
-```
-API_ENDPOINT="https://api.digitransit.fi/routing/v2/hsl/gtfs/v1"
-
-API_KEY=[YOUR-API-KEY]
-
-STOP_IDS=[YOUR-STOP-IDS]
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ STOP_IDS=[YOUR-STOP-IDS]
 - [x] Connect to Digitransit API to retrieve local departure information
 - [x] Track multiple STOP_ID values at the same time
 - [ ] Filter specific routes at tracked STOP_ID to exclude any that are not relevant
-- [ ] Interface with a display (ex. [TRMNL](https://usetrmnl.com/)) running a service to update the results at regular intervals
+- [ ] Interface with a display technology (ex. [TRMNL](https://usetrmnl.com/)) running a service to update the results at regular intervals

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ I've built this project to gather the realtime departure schedule from my local 
 
 2. Add a `.env` file to the root folder of your project, with the following information
    - `API_KEY` is provided after signing up for a development account on the [Digitransit Portal](https://portal-api.digitransit.fi/)
-   - `STOP_ID` should be set for your preferred HSL stop location. See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details
+   - `STOP_IDS` should be set for your preferred HSL stop location. See [Digitransit Documentation](https://digitransit.fi/en/developers/apis/1-routing-api/stops/) for details.
+     - Supports a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321")
 
 ```
 API_ENDPOINT="https://api.digitransit.fi/routing/v2/hsl/gtfs/v1"
 
 API_KEY=[YOUR-API-KEY]
 
-STOP_ID=[YOUR-STOP-ID]
+STOP_IDS=[YOUR-STOP-IDS]
 ```
 
 ---
@@ -27,6 +28,6 @@ STOP_ID=[YOUR-STOP-ID]
 ### Future Features
 
 - [x] Connect to Digitransit API to retrieve local departure information
-- [ ] Track multiple STOP_IDs at the same time
+- [x] Track multiple STOP_ID values at the same time
 - [ ] Filter specific routes at tracked STOP_ID to exclude any that are not relevant
-- [ ] Allow data to be shown on a display (ex. [TRMNL](https://usetrmnl.com/)) which updates at regular intervals
+- [ ] Interface with a display (ex. [TRMNL](https://usetrmnl.com/)) running a service to update the results at regular intervals

--- a/main.py
+++ b/main.py
@@ -8,47 +8,7 @@ from dotenv import load_dotenv
 load_dotenv()
 API_KEY = os.getenv("API_KEY")
 API_ENDPOINT = os.getenv("API_ENDPOINT")
-STOP_ID = os.getenv("STOP_ID") # 1 value
 STOP_IDS = os.getenv("STOP_IDS") # multiple values
-
-# The GraphQL query to get the next departures.
-# We are asking for the stop name and the next 5 departures.
-# The query also specifies which data fields we want for each departure,
-# such as the tram number, destination (headsign), and real-time departure time.
-# query_single = """
-# {
-#   stop(id: "%s") {
-#     name
-#     stoptimesWithoutPatterns(numberOfDepartures: 5) {
-#       realtimeDeparture
-#       headsign
-#       trip {
-#         route {
-#           shortName
-#         }
-#       }
-#     }
-#   }
-# }
-# """ % STOP_ID
-
-# query_multi = """
-# {
-#   stops(ids: ["%s"]) {
-#     name
-#     stoptimesWithoutPatterns(numberOfDepartures: 5) {
-#       realtimeDeparture
-#       headsign
-#       trip {
-#         route {
-#           shortName
-#         }
-#       }
-#     }
-#   }
-# }
-# """ % "\", \"".join(STOP_IDS.split(",")) #Format STOP_IDS for GraphQL query
-
 
 headers = {
     'Content-Type': 'application/graphql'
@@ -57,72 +17,8 @@ parameters = {
     'digitransit-subscription-key': API_KEY
 }
 
-# Get Next Departures for a single STOP_ID
-def get_next_departures_single():
-    """
-    Fetches and prints the next transit departures for the specified stop.
-    """
 
-    # Check if the required environment variables are set.
-    if not API_KEY or not API_ENDPOINT or not STOP_ID:
-        print("Error: Required environment variables are missing.")
-        print("Please ensure API_KEY, API_ENDPOINT, and STOP_ID are set in your .env file or environment.")
-        return
-
-    try:
-        # Make the POST request to the API with the GraphQL query.
-        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=getGraphQL_query(multi=False))
-        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
-
-        data = response.json()
-
-        # Check if the data contains the expected structure.
-        if "data" not in data or data["data"]["stop"] is None:
-            print("Error: Could not retrieve stop data. Please check the stop ID or API key.")
-            return
-
-        stop_data = data["data"]["stop"]
-        stop_name = stop_data["name"]
-        departures = stop_data["stoptimesWithoutPatterns"]
-
-        print(f"Next departures for stop: {stop_name}\n")
-
-        if not departures:
-            print("No upcoming departures found.")
-            return
-
-        for i, departure in enumerate(departures):
-            # The API returns departure time as a number of seconds from the beginning of the current day.
-            departure_timestamp_seconds = departure["realtimeDeparture"]
-            start_of_day = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
-            departure_datetime = start_of_day + datetime.timedelta(seconds=departure_timestamp_seconds)
-            
-            # Format the correctly calculated datetime object into a readable time string.
-            departure_time = departure_datetime.strftime('%H:%M:%S')
-            # Extract the transit line number and destination.
-            transit_number = departure["trip"]["route"]["shortName"]
-            destination = departure["headsign"]
-
-            print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time}")
-
-    except requests.exceptions.RequestException as e:
-        # Check for specific 401 error and provide a more helpful message.
-        if e.response and e.response.status_code == 401:
-            print("Error: 401 Unauthorized. The API key is likely missing, incorrect, or expired.")
-            print("Please ensure you have replaced 'YOUR_API_KEY_HERE' with a valid key and that it is in the correct header.")
-        elif e.response and e.response.status_code == 404:
-            print("Error: 404 Not Found. The API endpoint may be incorrect or deprecated.")
-            print("The code has been updated to use the correct endpoint. Please try again.")
-        else:
-            print(f"An error occurred while connecting to the API: {e}")
-    except json.JSONDecodeError:
-        print("Error: The API response was not valid JSON.")
-    except KeyError as e:
-        print(f"Error: Missing key in API response data: {e}")
-
-
-# Get Next Departures for all STOP_IDS
-def get_next_departures_multi():
+def get_next_departures():
     """
     Fetches and prints the next transit departures for the specified stop.
     """
@@ -135,7 +31,7 @@ def get_next_departures_multi():
 
     try:
         # Make the POST request to the API with the GraphQL query.
-        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=getGraphQL_query(multi=True))
+        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=getGraphQL_query())
         response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
 
         data = response.json()
@@ -149,9 +45,10 @@ def get_next_departures_multi():
         for s in stop_data:
                 
             stop_name = s["name"]
+            vehicle_mode = s["vehicleMode"]
             departures = s["stoptimesWithoutPatterns"]
 
-            print(f"Next departures for stop: {stop_name}\n")
+            print(f"\nNext departures for stop: {stop_name} {vehicle_mode}:")
 
             if not departures:
                 print("No upcoming departures found.")
@@ -187,31 +84,18 @@ def get_next_departures_multi():
         print(f"Error: Missing key in API response data: {e}")
 
 
-def getGraphQL_query(multi = False):
-    if(multi == False):
-       #Query gathers data for a single STOP_ID
-       return """
-       {
-        stop(id: "%s") {
-            name
-            stoptimesWithoutPatterns(numberOfDepartures: 5) {
-            realtimeDeparture
-            headsign
-            trip {
-                route {
-                shortName
-                }
-            }
-            }
-        }
-        }
-        """ % STOP_ID
-    else:
-        #Query gathers data for all configured STOP_IDS
-        return """
+def getGraphQL_query():
+    # GraphQL query to retrieve next departure data
+    # We are gathering data for the next 5 departures.
+    # The query also specifies which data fields we want for each departure,
+    # such as the tram number, destination (headsign), and real-time departure time.
+    
+    # STOP_IDS .env variable supports a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321")
+    query = """
         {
         stops(ids: ["%s"]) {
             name
+            vehicleMode
             stoptimesWithoutPatterns(numberOfDepartures: 5) {
             realtimeDeparture
             headsign
@@ -224,7 +108,9 @@ def getGraphQL_query(multi = False):
         }
         }
         """ % "\", \"".join(STOP_IDS.split(",")) #Format STOP_IDS for GraphQL query
+    
+    return query
 
 
 if __name__ == "__main__":
-    get_next_departures_multi()
+    get_next_departures()

--- a/main.py
+++ b/main.py
@@ -20,13 +20,13 @@ parameters = {
 
 def get_next_departures():
     """
-    Fetches and prints the next transit departures for the specified stop.
+    Fetches and prints the next transit departures for the specified stop(s).
     """
 
     # Check if the required environment variables are set.
     if not API_KEY or not API_ENDPOINT or not STOP_IDS:
         print("Error: Required environment variables are missing.")
-        print("Please ensure API_KEY, API_ENDPOINT, and STOP_ID are set in your .env file or environment.")
+        print("Please ensure API_KEY, API_ENDPOINT, and STOP_IDS are set in your .env file")
         return
 
     try:
@@ -61,7 +61,7 @@ def get_next_departures():
                 departure_datetime = start_of_day + datetime.timedelta(seconds=departure_timestamp_seconds)
                 current_datetime = datetime.datetime.now()
 
-                # Calculate time until departure
+                # Calculate time until departure in minutes
                 seconds_to_departure = (departure_datetime - current_datetime).seconds
                 time_to_departure = ""
                 if(seconds_to_departure > 0):
@@ -105,7 +105,7 @@ def getGraphQL_query():
         stops(ids: ["%s"]) {
             name
             vehicleMode
-            stoptimesWithoutPatterns(numberOfDepartures: 5) {
+            stoptimesWithoutPatterns(numberOfDepartures: 5, omitNonPickups: true) {
             realtimeDeparture
             headsign
             trip {

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def get_next_departures():
             vehicle_mode = s["vehicleMode"]
             departures = s["stoptimesWithoutPatterns"]
 
-            print(f"\nNext departures for stop: {stop_name} {vehicle_mode}:")
+            print(f"\nNext departures for {vehicle_mode} stop: {stop_name}:")
 
             if not departures:
                 print("No upcoming departures found.")
@@ -63,9 +63,11 @@ def get_next_departures():
 
                 # Calculate time until departure
                 seconds_to_departure = (departure_datetime - current_datetime).seconds
-                minutes_to_departure = 0
+                time_to_departure = ""
                 if(seconds_to_departure > 0):
-                    minutes_to_departure = seconds_to_departure // 60
+                    time_to_departure = f"{seconds_to_departure // 60} min"
+                else:
+                    time_to_departure = "DEPARTED"
 
                 # Format the correctly calculated datetime object into a readable time string.
                 departure_time = departure_datetime.strftime('%H:%M:%S')
@@ -73,7 +75,7 @@ def get_next_departures():
                 transit_number = departure["trip"]["route"]["shortName"]
                 destination = departure["headsign"]
 
-                print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time} - ({minutes_to_departure} min)")
+                print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time} - ({time_to_departure})")
 
     except requests.exceptions.RequestException as e:
         # Check for specific 401 error and provide a more helpful message.

--- a/main.py
+++ b/main.py
@@ -8,28 +8,46 @@ from dotenv import load_dotenv
 load_dotenv()
 API_KEY = os.getenv("API_KEY")
 API_ENDPOINT = os.getenv("API_ENDPOINT")
-STOP_ID = os.getenv("STOP_ID")
+STOP_ID = os.getenv("STOP_ID") # 1 value
+STOP_IDS = os.getenv("STOP_IDS") # multiple values
 
 # The GraphQL query to get the next departures.
 # We are asking for the stop name and the next 5 departures.
 # The query also specifies which data fields we want for each departure,
 # such as the tram number, destination (headsign), and real-time departure time.
-query = """
-{
-  stop(id: "%s") {
-    name
-    stoptimesWithoutPatterns(numberOfDepartures: 5) {
-      realtimeDeparture
-      headsign
-      trip {
-        route {
-          shortName
-        }
-      }
-    }
-  }
-}
-""" % STOP_ID
+# query_single = """
+# {
+#   stop(id: "%s") {
+#     name
+#     stoptimesWithoutPatterns(numberOfDepartures: 5) {
+#       realtimeDeparture
+#       headsign
+#       trip {
+#         route {
+#           shortName
+#         }
+#       }
+#     }
+#   }
+# }
+# """ % STOP_ID
+
+# query_multi = """
+# {
+#   stops(ids: ["%s"]) {
+#     name
+#     stoptimesWithoutPatterns(numberOfDepartures: 5) {
+#       realtimeDeparture
+#       headsign
+#       trip {
+#         route {
+#           shortName
+#         }
+#       }
+#     }
+#   }
+# }
+# """ % "\", \"".join(STOP_IDS.split(",")) #Format STOP_IDS for GraphQL query
 
 
 headers = {
@@ -39,7 +57,8 @@ parameters = {
     'digitransit-subscription-key': API_KEY
 }
 
-def get_next_departures():
+# Get Next Departures for a single STOP_ID
+def get_next_departures_single():
     """
     Fetches and prints the next transit departures for the specified stop.
     """
@@ -52,7 +71,7 @@ def get_next_departures():
 
     try:
         # Make the POST request to the API with the GraphQL query.
-        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=query)
+        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=getGraphQL_query(multi=False))
         response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
 
         data = response.json()
@@ -101,5 +120,111 @@ def get_next_departures():
     except KeyError as e:
         print(f"Error: Missing key in API response data: {e}")
 
+
+# Get Next Departures for all STOP_IDS
+def get_next_departures_multi():
+    """
+    Fetches and prints the next transit departures for the specified stop.
+    """
+
+    # Check if the required environment variables are set.
+    if not API_KEY or not API_ENDPOINT or not STOP_IDS:
+        print("Error: Required environment variables are missing.")
+        print("Please ensure API_KEY, API_ENDPOINT, and STOP_ID are set in your .env file or environment.")
+        return
+
+    try:
+        # Make the POST request to the API with the GraphQL query.
+        response = requests.post(API_ENDPOINT, params=parameters, headers=headers, data=getGraphQL_query(multi=True))
+        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
+
+        data = response.json()
+
+        # Check if the data contains the expected structure.
+        if "data" not in data or data["data"]["stops"] is None:
+            print("Error: Could not retrieve stop data. Please check the stop ID or API key.")
+            return
+
+        stop_data = data["data"]["stops"]
+        for s in stop_data:
+                
+            stop_name = s["name"]
+            departures = s["stoptimesWithoutPatterns"]
+
+            print(f"Next departures for stop: {stop_name}\n")
+
+            if not departures:
+                print("No upcoming departures found.")
+                return
+
+            for i, departure in enumerate(departures):
+                # The API returns departure time as a number of seconds from the beginning of the current day.
+                departure_timestamp_seconds = departure["realtimeDeparture"]
+                start_of_day = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
+                departure_datetime = start_of_day + datetime.timedelta(seconds=departure_timestamp_seconds)
+                
+                # Format the correctly calculated datetime object into a readable time string.
+                departure_time = departure_datetime.strftime('%H:%M:%S')
+                # Extract the transit line number and destination.
+                transit_number = departure["trip"]["route"]["shortName"]
+                destination = departure["headsign"]
+
+                print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time}")
+
+    except requests.exceptions.RequestException as e:
+        # Check for specific 401 error and provide a more helpful message.
+        if e.response and e.response.status_code == 401:
+            print("Error: 401 Unauthorized. The API key is likely missing, incorrect, or expired.")
+            print("Please ensure you have replaced 'YOUR_API_KEY_HERE' with a valid key and that it is in the correct header.")
+        elif e.response and e.response.status_code == 404:
+            print("Error: 404 Not Found. The API endpoint may be incorrect or deprecated.")
+            print("The code has been updated to use the correct endpoint. Please try again.")
+        else:
+            print(f"An error occurred while connecting to the API: {e}")
+    except json.JSONDecodeError:
+        print("Error: The API response was not valid JSON.")
+    except KeyError as e:
+        print(f"Error: Missing key in API response data: {e}")
+
+
+def getGraphQL_query(multi = False):
+    if(multi == False):
+       #Query gathers data for a single STOP_ID
+       return """
+       {
+        stop(id: "%s") {
+            name
+            stoptimesWithoutPatterns(numberOfDepartures: 5) {
+            realtimeDeparture
+            headsign
+            trip {
+                route {
+                shortName
+                }
+            }
+            }
+        }
+        }
+        """ % STOP_ID
+    else:
+        #Query gathers data for all configured STOP_IDS
+        return """
+        {
+        stops(ids: ["%s"]) {
+            name
+            stoptimesWithoutPatterns(numberOfDepartures: 5) {
+            realtimeDeparture
+            headsign
+            trip {
+                route {
+                shortName
+                }
+            }
+            }
+        }
+        }
+        """ % "\", \"".join(STOP_IDS.split(",")) #Format STOP_IDS for GraphQL query
+
+
 if __name__ == "__main__":
-    get_next_departures()
+    get_next_departures_multi()

--- a/main.py
+++ b/main.py
@@ -59,14 +59,21 @@ def get_next_departures():
                 departure_timestamp_seconds = departure["realtimeDeparture"]
                 start_of_day = datetime.datetime.combine(datetime.date.today(), datetime.time.min)
                 departure_datetime = start_of_day + datetime.timedelta(seconds=departure_timestamp_seconds)
-                
+                current_datetime = datetime.datetime.now()
+
+                # Calculate time until departure
+                seconds_to_departure = (departure_datetime - current_datetime).seconds
+                minutes_to_departure = 0
+                if(seconds_to_departure > 0):
+                    minutes_to_departure = seconds_to_departure // 60
+
                 # Format the correctly calculated datetime object into a readable time string.
                 departure_time = departure_datetime.strftime('%H:%M:%S')
                 # Extract the transit line number and destination.
                 transit_number = departure["trip"]["route"]["shortName"]
                 destination = departure["headsign"]
 
-                print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time}")
+                print(f"  {i+1}. Line {transit_number} to {destination} at {departure_time} - ({minutes_to_departure} min)")
 
     except requests.exceptions.RequestException as e:
         # Check for specific 401 error and provide a more helpful message.


### PR DESCRIPTION
### Changes Implemented:
1. Replaced `STOP_ID` parameter with `STOP_IDS` in the .env file.  This parameter now supports either a single stop (ex. "HSL:11235") or multiple stops in csv format (ex. "HSL:11235,HSL:81321").
2. Updated README.md to document new changes

### New Functionality
Results are displayed for each stop specified in the .env file.  

Fixes #1 